### PR TITLE
Add 'upload' functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UploadCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UploadCommand.java
@@ -1,0 +1,77 @@
+package seedu.address.logic.commands;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Uploads a file to CLIpboard. If file already exists in CLIpboard, old file will be replaced.
+ * File will be saved to the data folder.
+ */
+public class UploadCommand extends Command {
+
+    public static final String COMMAND_WORD = "upload";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Uploads a file from a specified absolute file path to CLIpboard.\n"
+            + "Parameters: FILEPATH (must be a non-empty and valid file path)\n"
+            + "Example: " + COMMAND_WORD + " /Users/AlexYeoh/Desktop/A0123456X.png";
+
+    private static final String MESSAGE_INVALID_FILEPATH = "File path is not valid!";
+    private static final String DESTINATION_FILEPATH = "./data";
+
+    private final Path path;
+
+    /**
+     * @param path of target file that will be uploaded.
+     */
+    public UploadCommand(Path path) {
+        requireNonNull(path);
+        this.path = path;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        try {
+            Path sourcePath = path;
+            Path destinationPath = Paths.get(DESTINATION_FILEPATH);
+            Files.copy(sourcePath, destinationPath.resolve(sourcePath.getFileName()), REPLACE_EXISTING);
+            return new CommandResult(generateSuccessMessage(sourcePath));
+        } catch (IOException e) {
+            throw new CommandException(MESSAGE_INVALID_FILEPATH);
+        }
+    }
+
+    /**
+     * Generates a command execution success message based on the
+     * name of file that has been uploaded.
+     * {@code addedPath}.
+     */
+    private String generateSuccessMessage(Path addedPath) {
+        return "File " + addedPath.getFileName() + " successfully added to CLIpboard";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UploadCommand)) {
+            return false;
+        }
+
+        // state check
+        UploadCommand e = (UploadCommand) other;
+        return path.equals(e.path);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.UploadCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -71,6 +72,9 @@ public class AddressBookParser {
 
         case RemarkCommand.COMMAND_WORD:
             return new RemarkCommandParser().parse(arguments);
+
+        case UploadCommand.COMMAND_WORD:
+            return new UploadCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/UploadCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UploadCommandParser.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import seedu.address.logic.commands.UploadCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new UploadCommand object
+ */
+public class UploadCommandParser implements Parser<UploadCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the UploadCommand
+     * and returns an UploadCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UploadCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UploadCommand.MESSAGE_USAGE));
+        }
+
+        Path path = Paths.get(trimmedArgs);
+        return new UploadCommand(path);
+    }
+}


### PR DESCRIPTION
Previously, users would have to manually transfer a file (e.g. a student photo) to the data folder in CLIpboard.

Let's automate this process by allowing users to upload files by inputting the target file path into the command line interface of CLIpboard.