### PR TITLE
Add Copy Command

### DIFF
--- a/src/main/java/tfifteenfour/clipboard/logic/commands/CopyCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/CopyCommand.java
@@ -1,0 +1,80 @@
+package tfifteenfour.clipboard.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+
+import javafx.collections.ObservableList;
+import tfifteenfour.clipboard.commons.core.Messages;
+import tfifteenfour.clipboard.commons.core.index.Index;
+import tfifteenfour.clipboard.logic.CurrentSelection;
+import tfifteenfour.clipboard.logic.PageType;
+import tfifteenfour.clipboard.logic.commands.exceptions.CommandException;
+import tfifteenfour.clipboard.model.Model;
+import tfifteenfour.clipboard.model.course.Group;
+import tfifteenfour.clipboard.model.student.Student;
+
+/**
+ * Copies the email of the student in the index to clipboard
+ */
+public class CopyCommand extends Command {
+
+    public static final String COMMAND_WORD = "copy";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Copies the email of the student in the index "
+            + "to the user's clipboard";
+
+    public static final String MESSAGE_SUCCESS = "Successfully copied selected student's email to clipboard";
+
+    private final Index index;
+
+    /**
+     * Constructor for the copy command
+     * @param index of the student to copy the email from
+     */
+    public CopyCommand(Index index) {
+        super(false);
+        this.index = index;
+    }
+    @Override
+    public CommandResult execute(Model model, CurrentSelection currentSelection) throws CommandException {
+        requireNonNull(model);
+
+        if (currentSelection.getCurrentPage() != PageType.STUDENT_PAGE) {
+            throw new CommandException("Wrong page. Navigate to student page to copy selected student email");
+        }
+
+        Group group = currentSelection.getSelectedGroup();
+        ObservableList<Student> studentList = group.getUnmodifiableStudentList();
+
+        if (index.getZeroBased() >= studentList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        } else {
+            Student selectedStudent = studentList.get(index.getZeroBased());
+            copyToClipboard(selectedStudent);
+        }
+
+        return new CommandResult(this,
+                String.format(MESSAGE_SUCCESS,
+                        model.getUnmodifiableFilteredStudentList().size()), willModifyState);
+    }
+
+    /**
+     * Takes in student and copies the email of the student to clipboard
+     * @param student of the selected index
+     */
+    public void copyToClipboard(Student student) {
+        String email = student.getEmail().toString();
+        Toolkit.getDefaultToolkit()
+                .getSystemClipboard()
+                .setContents(new StringSelection(email), null);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CopyCommand // instanceof handles nulls
+                && index.equals(((CopyCommand) other).index)); // state check
+    }
+}

--- a/src/main/java/tfifteenfour/clipboard/logic/parser/CopyCommandParser.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/parser/CopyCommandParser.java
@@ -1,0 +1,29 @@
+package tfifteenfour.clipboard.logic.parser;
+
+import static tfifteenfour.clipboard.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import tfifteenfour.clipboard.commons.core.index.Index;
+import tfifteenfour.clipboard.logic.commands.CopyCommand;
+import tfifteenfour.clipboard.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class CopyCommandParser implements Parser<CopyCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public CopyCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new CopyCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/tfifteenfour/clipboard/logic/parser/RosterParser.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/parser/RosterParser.java
@@ -10,6 +10,7 @@ import tfifteenfour.clipboard.logic.CurrentSelection;
 import tfifteenfour.clipboard.logic.commands.BackCommand;
 import tfifteenfour.clipboard.logic.commands.ClearCommand;
 import tfifteenfour.clipboard.logic.commands.Command;
+import tfifteenfour.clipboard.logic.commands.CopyCommand;
 import tfifteenfour.clipboard.logic.commands.ExitCommand;
 import tfifteenfour.clipboard.logic.commands.HelpCommand;
 import tfifteenfour.clipboard.logic.commands.HomeCommand;
@@ -115,6 +116,9 @@ public class RosterParser {
 
         case HomeCommand.COMMAND_WORD:
             return new HomeCommand();
+
+        case CopyCommand.COMMAND_WORD:
+            return new CopyCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);


### PR DESCRIPTION
Add copy command which copies the email of the selected student corresponding to the index to clipboard of the user
Format: copy `index`
Example: copy 1

Note: it should only work on the Students page
