### PR TITLE
Fix broken edit command due to remodelling

### DIFF
--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCommand.java
@@ -1,0 +1,11 @@
+package tfifteenfour.clipboard.logic.commands.editcommand;
+
+import tfifteenfour.clipboard.logic.commands.Command;
+
+public abstract class EditCommand extends Command {
+    public static final String COMMAND_WORD = "edit";
+
+    public EditCommand() {
+        super(true);
+    }
+}

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCommand.java
@@ -2,6 +2,10 @@ package tfifteenfour.clipboard.logic.commands.editcommand;
 
 import tfifteenfour.clipboard.logic.commands.Command;
 
+/**
+ * Edits an existing item in the clipboard. Available options
+ * are course, group, session and student.
+ */
 public abstract class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
 

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCourseCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCourseCommand.java
@@ -1,5 +1,9 @@
 package tfifteenfour.clipboard.logic.commands.editcommand;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
 import tfifteenfour.clipboard.commons.core.Messages;
 import tfifteenfour.clipboard.commons.core.index.Index;
 import tfifteenfour.clipboard.logic.CurrentSelection;
@@ -10,10 +14,6 @@ import tfifteenfour.clipboard.model.Model;
 import tfifteenfour.clipboard.model.course.Course;
 import tfifteenfour.clipboard.model.course.Group;
 
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-
 public class EditCourseCommand extends EditCommand {
     public static final String COMMAND_TYPE_WORD = "course";
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -23,6 +23,8 @@ public class EditCourseCommand extends EditCommand {
             + " 1 CS2105";
 
     public static final String MESSAGE_SUCCESS = "Edited course: %1$s to %2$s";
+    public static final String MESSAGE_DUPLICATE_COURSE = "This course already exists";
+
 
     private final Index index;
     private final Course newCourse;
@@ -45,6 +47,8 @@ public class EditCourseCommand extends EditCommand {
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_COURSE_DISPLAYED_INDEX);
+        } else if (lastShownList.contains(newCourse)) {
+            throw new CommandException(MESSAGE_DUPLICATE_COURSE);
         }
 
         Course courseToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCourseCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCourseCommand.java
@@ -1,0 +1,2 @@
+package tfifteenfour.clipboard.logic.commands.editcommand;public class EditCourseCommand {
+}

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCourseCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCourseCommand.java
@@ -14,6 +14,9 @@ import tfifteenfour.clipboard.model.Model;
 import tfifteenfour.clipboard.model.course.Course;
 import tfifteenfour.clipboard.model.course.Group;
 
+/**
+ * Edits the name of an existing course.
+ */
 public class EditCourseCommand extends EditCommand {
     public static final String COMMAND_TYPE_WORD = "course";
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -29,7 +32,11 @@ public class EditCourseCommand extends EditCommand {
     private final Index index;
     private final Course newCourse;
 
-
+    /**
+     * Constructs an {@code EditCourseCommand} with the specified index and new course.
+     * @param index The index of the course to be edited.
+     * @param newCourse The new course to replace the existing course.
+     */
     public EditCourseCommand(Index index, Course newCourse) {
         this.index = index;
         this.newCourse = newCourse;

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCourseCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditCourseCommand.java
@@ -1,2 +1,61 @@
-package tfifteenfour.clipboard.logic.commands.editcommand;public class EditCourseCommand {
+package tfifteenfour.clipboard.logic.commands.editcommand;
+
+import tfifteenfour.clipboard.commons.core.Messages;
+import tfifteenfour.clipboard.commons.core.index.Index;
+import tfifteenfour.clipboard.logic.CurrentSelection;
+import tfifteenfour.clipboard.logic.PageType;
+import tfifteenfour.clipboard.logic.commands.CommandResult;
+import tfifteenfour.clipboard.logic.commands.exceptions.CommandException;
+import tfifteenfour.clipboard.model.Model;
+import tfifteenfour.clipboard.model.course.Course;
+import tfifteenfour.clipboard.model.course.Group;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class EditCourseCommand extends EditCommand {
+    public static final String COMMAND_TYPE_WORD = "course";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Edits a course name."
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD
+            + " 1 CS2105";
+
+    public static final String MESSAGE_SUCCESS = "Edited course: %1$s to %2$s";
+
+    private final Index index;
+    private final Course newCourse;
+
+
+    public EditCourseCommand(Index index, Course newCourse) {
+        this.index = index;
+        this.newCourse = newCourse;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CurrentSelection currentSelection) throws CommandException {
+        requireNonNull(model);
+
+        if (currentSelection.getCurrentPage() != PageType.COURSE_PAGE) {
+            throw new CommandException("Wrong page. Navigate to course page to edit course");
+        }
+
+        List<Course> lastShownList = model.getUnmodifiableFilteredCourseList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_COURSE_DISPLAYED_INDEX);
+        }
+
+        Course courseToEdit = lastShownList.get(index.getZeroBased());
+        List<Group> groups = courseToEdit.getUnmodifiableGroupList();
+        for (Group group : groups) {
+            newCourse.addGroup(group);
+        }
+
+        model.getModifiableFilteredCourseList().set(index.getZeroBased(), newCourse);
+
+        return new CommandResult(this, String.format(MESSAGE_SUCCESS, courseToEdit, newCourse), willModifyState);
+    }
+
 }

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditGroupCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditGroupCommand.java
@@ -1,0 +1,2 @@
+package tfifteenfour.clipboard.logic.commands.editcommand;public class EditGroupCommand {
+}

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditGroupCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditGroupCommand.java
@@ -1,5 +1,9 @@
 package tfifteenfour.clipboard.logic.commands.editcommand;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
 import tfifteenfour.clipboard.commons.core.Messages;
 import tfifteenfour.clipboard.commons.core.index.Index;
 import tfifteenfour.clipboard.logic.CurrentSelection;
@@ -12,10 +16,6 @@ import tfifteenfour.clipboard.model.course.Group;
 import tfifteenfour.clipboard.model.course.Session;
 import tfifteenfour.clipboard.model.student.Student;
 
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-
 public class EditGroupCommand extends EditCommand {
     public static final String COMMAND_TYPE_WORD = "group";
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -25,6 +25,7 @@ public class EditGroupCommand extends EditCommand {
             + " 1 T01";
 
     public static final String MESSAGE_SUCCESS = "Edited group: %1$s to %2$s";
+    public static final String MESSAGE_DUPLICATE_GROUP = "This group already exists in the course";
 
     private final Index index;
     private final Group newGroup;
@@ -43,11 +44,13 @@ public class EditGroupCommand extends EditCommand {
             throw new CommandException("Wrong page. Navigate to group page to edit group");
         }
 
-        Course selectCourse = currentSelection.getSelectedCourse();
-        List<Group> lastShownList = selectCourse.getModifiableGrouplist();
+        Course selectedCourse = currentSelection.getSelectedCourse();
+        List<Group> lastShownList = selectedCourse.getModifiableGrouplist();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_GROUP_DISPLAYED_INDEX);
+        } else if (selectedCourse.hasGroup(newGroup)) {
+            throw new CommandException(MESSAGE_DUPLICATE_GROUP);
         }
 
         Group GroupToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditGroupCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditGroupCommand.java
@@ -1,2 +1,63 @@
-package tfifteenfour.clipboard.logic.commands.editcommand;public class EditGroupCommand {
+package tfifteenfour.clipboard.logic.commands.editcommand;
+
+import tfifteenfour.clipboard.commons.core.Messages;
+import tfifteenfour.clipboard.commons.core.index.Index;
+import tfifteenfour.clipboard.logic.CurrentSelection;
+import tfifteenfour.clipboard.logic.PageType;
+import tfifteenfour.clipboard.logic.commands.CommandResult;
+import tfifteenfour.clipboard.logic.commands.exceptions.CommandException;
+import tfifteenfour.clipboard.model.Model;
+import tfifteenfour.clipboard.model.course.Course;
+import tfifteenfour.clipboard.model.course.Group;
+import tfifteenfour.clipboard.model.course.Session;
+import tfifteenfour.clipboard.model.student.Student;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class EditGroupCommand extends EditCommand {
+    public static final String COMMAND_TYPE_WORD = "group";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Edits a group name."
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD
+            + " 1 T01";
+
+    public static final String MESSAGE_SUCCESS = "Edited group: %1$s to %2$s";
+
+    private final Index index;
+    private final Group newGroup;
+
+
+    public EditGroupCommand(Index index, Group newGroup) {
+        this.index = index;
+        this.newGroup = newGroup;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CurrentSelection currentSelection) throws CommandException {
+        requireNonNull(model);
+
+        if (currentSelection.getCurrentPage() != PageType.GROUP_PAGE) {
+            throw new CommandException("Wrong page. Navigate to group page to edit group");
+        }
+
+        Course selectCourse = currentSelection.getSelectedCourse();
+        List<Group> lastShownList = selectCourse.getModifiableGrouplist();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_GROUP_DISPLAYED_INDEX);
+        }
+
+        Group GroupToEdit = lastShownList.get(index.getZeroBased());
+        List<Student> students = GroupToEdit.getUnmodifiableStudentList();
+        List<Session> sessions = GroupToEdit.getUnmodifiableSessionList();
+        students.forEach(newGroup::addStudent);
+        sessions.forEach(newGroup::addSession);
+
+        lastShownList.set(index.getZeroBased(), newGroup);
+        return new CommandResult(this, String.format(MESSAGE_SUCCESS, GroupToEdit, newGroup), willModifyState);
+    }
+
 }

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditGroupCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditGroupCommand.java
@@ -16,6 +16,9 @@ import tfifteenfour.clipboard.model.course.Group;
 import tfifteenfour.clipboard.model.course.Session;
 import tfifteenfour.clipboard.model.student.Student;
 
+/**
+ * Edits the name of a group.
+ */
 public class EditGroupCommand extends EditCommand {
     public static final String COMMAND_TYPE_WORD = "group";
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -30,6 +33,12 @@ public class EditGroupCommand extends EditCommand {
     private final Index index;
     private final Group newGroup;
 
+    /**
+     * Constructs a EditGroupCommand object with the given index and new group.
+     *
+     * @param index   The index of the group to edit.
+     * @param newGroup The new Group object with the updated name.
+     */
 
     public EditGroupCommand(Index index, Group newGroup) {
         this.index = index;
@@ -53,14 +62,14 @@ public class EditGroupCommand extends EditCommand {
             throw new CommandException(MESSAGE_DUPLICATE_GROUP);
         }
 
-        Group GroupToEdit = lastShownList.get(index.getZeroBased());
-        List<Student> students = GroupToEdit.getUnmodifiableStudentList();
-        List<Session> sessions = GroupToEdit.getUnmodifiableSessionList();
+        Group groupToEdit = lastShownList.get(index.getZeroBased());
+        List<Student> students = groupToEdit.getUnmodifiableStudentList();
+        List<Session> sessions = groupToEdit.getUnmodifiableSessionList();
         students.forEach(newGroup::addStudent);
         sessions.forEach(newGroup::addSession);
 
         lastShownList.set(index.getZeroBased(), newGroup);
-        return new CommandResult(this, String.format(MESSAGE_SUCCESS, GroupToEdit, newGroup), willModifyState);
+        return new CommandResult(this, String.format(MESSAGE_SUCCESS, groupToEdit, newGroup), willModifyState);
     }
 
 }

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditSessionCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditSessionCommand.java
@@ -14,6 +14,9 @@ import tfifteenfour.clipboard.model.Model;
 import tfifteenfour.clipboard.model.course.Group;
 import tfifteenfour.clipboard.model.course.Session;
 
+/**
+ * Edits the name of a session in the gorup.
+ */
 public class EditSessionCommand extends EditCommand {
     public static final String COMMAND_TYPE_WORD = "session";
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -28,7 +31,11 @@ public class EditSessionCommand extends EditCommand {
     private final Index index;
     private final Session newSession;
 
-
+    /**
+     * Constructs an {@code EditSessionCommand} with the specified index and new session.
+     * @param index The index of the session to be edited.
+     * @param newSession The new session to be set.
+     */
     public EditSessionCommand(Index index, Session newSession) {
         this.index = index;
         this.newSession = newSession;

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditSessionCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditSessionCommand.java
@@ -1,2 +1,61 @@
-package tfifteenfour.clipboard.logic.commands.editcommand;public class EditSessionCommand {
+package tfifteenfour.clipboard.logic.commands.editcommand;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import tfifteenfour.clipboard.commons.core.Messages;
+import tfifteenfour.clipboard.commons.core.index.Index;
+import tfifteenfour.clipboard.logic.CurrentSelection;
+import tfifteenfour.clipboard.logic.PageType;
+import tfifteenfour.clipboard.logic.commands.CommandResult;
+import tfifteenfour.clipboard.logic.commands.exceptions.CommandException;
+import tfifteenfour.clipboard.model.Model;
+import tfifteenfour.clipboard.model.course.Group;
+import tfifteenfour.clipboard.model.course.Session;
+
+public class EditSessionCommand extends EditCommand {
+    public static final String COMMAND_TYPE_WORD = "session";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Edits a session name."
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD
+            + " 1 Tutorial1";
+
+    public static final String MESSAGE_SUCCESS = "Edited session: %1$s to %2$s";
+    public static final String MESSAGE_DUPLICATE_SESSION = "This session already exists in the course";
+
+    private final Index index;
+    private final Session newSession;
+
+
+    public EditSessionCommand(Index index, Session newSession) {
+        this.index = index;
+        this.newSession = newSession;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CurrentSelection currentSelection) throws CommandException {
+        requireNonNull(model);
+
+        if (currentSelection.getCurrentPage() != PageType.SESSION_PAGE) {
+            throw new CommandException("Wrong page. Navigate to session page to edit session");
+        }
+
+        Group selectGroup = currentSelection.getSelectedGroup();
+        List<Session> lastShownList = selectGroup.getModifiableSessionList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
+        } else if (selectGroup.hasSession(newSession)) {
+            throw new CommandException(MESSAGE_DUPLICATE_SESSION);
+        }
+
+        Session sessionToEdit = lastShownList.get(index.getZeroBased());
+        newSession.setAttendance(sessionToEdit.getAttendance());
+
+        lastShownList.set(index.getZeroBased(), newSession);
+        return new CommandResult(this, String.format(MESSAGE_SUCCESS, sessionToEdit, newSession), willModifyState);
+    }
+
 }

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditSessionCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditSessionCommand.java
@@ -1,0 +1,2 @@
+package tfifteenfour.clipboard.logic.commands.editcommand;public class EditSessionCommand {
+}

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditSessionCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditSessionCommand.java
@@ -42,12 +42,12 @@ public class EditSessionCommand extends EditCommand {
             throw new CommandException("Wrong page. Navigate to session page to edit session");
         }
 
-        Group selectGroup = currentSelection.getSelectedGroup();
-        List<Session> lastShownList = selectGroup.getModifiableSessionList();
+        Group selectedGroup = currentSelection.getSelectedGroup();
+        List<Session> lastShownList = selectedGroup.getModifiableSessionList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_SESSION_DISPLAYED_INDEX);
-        } else if (selectGroup.hasSession(newSession)) {
+        } else if (selectedGroup.hasSession(newSession)) {
             throw new CommandException(MESSAGE_DUPLICATE_SESSION);
         }
 

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditStudentCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditStudentCommand.java
@@ -1,0 +1,2 @@
+package tfifteenfour.clipboard.logic.commands.editcommand;public class EditStudentCommand {
+}

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditStudentCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditStudentCommand.java
@@ -1,2 +1,132 @@
-package tfifteenfour.clipboard.logic.commands.editcommand;public class EditStudentCommand {
+package tfifteenfour.clipboard.logic.commands.editcommand;
+
+import static java.util.Objects.requireNonNull;
+import static tfifteenfour.clipboard.logic.parser.CliSyntax.PREFIX_COURSE;
+import static tfifteenfour.clipboard.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static tfifteenfour.clipboard.logic.parser.CliSyntax.PREFIX_NAME;
+import static tfifteenfour.clipboard.logic.parser.CliSyntax.PREFIX_PHONE;
+import static tfifteenfour.clipboard.logic.parser.CliSyntax.PREFIX_STUDENTID;
+import static tfifteenfour.clipboard.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.List;
+
+import tfifteenfour.clipboard.commons.core.Messages;
+import tfifteenfour.clipboard.commons.core.index.Index;
+import tfifteenfour.clipboard.logic.CurrentSelection;
+import tfifteenfour.clipboard.logic.commands.CommandResult;
+import tfifteenfour.clipboard.logic.commands.exceptions.CommandException;
+import tfifteenfour.clipboard.logic.parser.NewEditCommandParser.EditStudentDescriptor;
+import tfifteenfour.clipboard.model.Model;
+import tfifteenfour.clipboard.model.course.Group;
+import tfifteenfour.clipboard.model.course.Session;
+import tfifteenfour.clipboard.model.student.Email;
+import tfifteenfour.clipboard.model.student.Name;
+import tfifteenfour.clipboard.model.student.Phone;
+import tfifteenfour.clipboard.model.student.Remark;
+import tfifteenfour.clipboard.model.student.Student;
+import tfifteenfour.clipboard.model.student.StudentId;
+
+/**
+ */
+public class EditStudentCommand extends EditCommand {
+    public static final String COMMAND_TYPE_WORD = "student";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the student identified "
+            + "by the index number used in the displayed student list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_STUDENTID + "STUDENTID] "
+            + "[" + PREFIX_COURSE + "MODULE]..."
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_PHONE + "91234567 "
+            + PREFIX_EMAIL + "johndoe@example.com";
+
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Student: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This student already exists in the address book.";
+
+    public static final Remark DEFAULT_REMARK = new Remark("");
+
+    private final Index index;
+    private final EditStudentDescriptor editStudentDescriptor;
+
+
+    /**
+     * @param index of the student in the filtered student list to edit
+     * @param editStudentDescriptor details to edit the student with
+     */
+    public EditStudentCommand(Index index, EditStudentDescriptor editStudentDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editStudentDescriptor);
+
+        this.index = index;
+        this.editStudentDescriptor = new EditStudentDescriptor(editStudentDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model, CurrentSelection currentSelection) throws CommandException {
+        requireNonNull(model);
+        Group selectedGroup = currentSelection.getSelectedGroup();
+        List<Student> lastShownList = selectedGroup.getModifiableStudentlist();
+        List<Session> sessions = selectedGroup.getModifiableSessionList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Student studentToEdit = lastShownList.get(index.getZeroBased());
+        Student editedStudent = createEditedStudent(studentToEdit, editStudentDescriptor);
+
+        if (!studentToEdit.isSameStudent(editedStudent) && model.hasStudent(editedStudent)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+
+        for (Session session : sessions) {
+            session.replaceStudent(studentToEdit, editedStudent);
+        }
+
+        lastShownList.set(index.getZeroBased(), editedStudent);
+        return new CommandResult(this, String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedStudent), willModifyState);
+    }
+
+    /**
+     * Creates and returns a {@code Student} with the details of {@code studentToEdit}
+     * edited with {@code editStudentDescriptor}.
+     */
+    private static Student createEditedStudent(Student studentToEdit, EditStudentDescriptor editStudentDescriptor) {
+        assert studentToEdit != null;
+
+        Name updatedName = editStudentDescriptor.getName().orElse(studentToEdit.getName());
+        Phone updatedPhone = editStudentDescriptor.getPhone().orElse(studentToEdit.getPhone());
+        Email updatedEmail = editStudentDescriptor.getEmail().orElse(studentToEdit.getEmail());
+        StudentId updatedStudentId = editStudentDescriptor.getStudentId().orElse(studentToEdit.getStudentId());
+        Remark remark = studentToEdit.getRemark();
+
+        return new Student(updatedName, updatedPhone, updatedEmail, updatedStudentId,
+                remark);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditStudentCommand)) {
+            return false;
+        }
+
+        // state check
+        EditStudentCommand e = (EditStudentCommand) other;
+        return index.equals(e.index)
+                && editStudentDescriptor.equals(e.editStudentDescriptor);
+    }
+
 }

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditStudentCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/editcommand/EditStudentCommand.java
@@ -27,6 +27,7 @@ import tfifteenfour.clipboard.model.student.Student;
 import tfifteenfour.clipboard.model.student.StudentId;
 
 /**
+ * Edits the information of a student.
  */
 public class EditStudentCommand extends EditCommand {
     public static final String COMMAND_TYPE_WORD = "student";

--- a/src/main/java/tfifteenfour/clipboard/logic/parser/NewEditCommandParser.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/parser/NewEditCommandParser.java
@@ -7,6 +7,7 @@ import tfifteenfour.clipboard.logic.commands.addcommand.AddSessionCommand;
 import tfifteenfour.clipboard.logic.commands.editcommand.EditCommand;
 import tfifteenfour.clipboard.logic.commands.editcommand.EditCourseCommand;
 import tfifteenfour.clipboard.logic.commands.editcommand.EditGroupCommand;
+import tfifteenfour.clipboard.logic.commands.editcommand.EditSessionCommand;
 import tfifteenfour.clipboard.logic.parser.exceptions.ParseException;
 import tfifteenfour.clipboard.model.course.Course;
 import tfifteenfour.clipboard.model.course.Group;
@@ -42,10 +43,12 @@ public class NewEditCommandParser implements Parser<EditCommand> {
             index = parseIndex(args);
             return new EditGroupCommand(index, newGroup);
         case SESSION:
-//            Session session = parseSessionInfo(args);
-//            return new EditSessionCommand(session);
+            Session newSession = parseSessionInfo(args);
+            index = parseIndex(args);
+            return new EditSessionCommand(index, newSession);
         case STUDENT:
 //            Student student = parseStudentInfo(args);
+//            index = parseIndex(args);
 //            return new EditStudentCommand(student);
         default:
             throw new ParseException("Invalid argument for add command");
@@ -80,11 +83,11 @@ public class NewEditCommandParser implements Parser<EditCommand> {
 
     private Session parseSessionInfo(String args) throws ParseException {
         String[] tokens = ArgumentTokenizer.tokenizeString(args);
-        if (tokens.length != 3) {
+        if (tokens.length != 4) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSessionCommand.MESSAGE_USAGE));
         }
 
-        Session session = ParserUtil.parseSession(tokens[2]);
+        Session session = ParserUtil.parseSession(tokens[3]);
         return session;
     }
 

--- a/src/main/java/tfifteenfour/clipboard/logic/parser/NewEditCommandParser.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/parser/NewEditCommandParser.java
@@ -33,9 +33,17 @@ import tfifteenfour.clipboard.model.student.Phone;
 import tfifteenfour.clipboard.model.student.StudentId;
 import tfifteenfour.clipboard.model.tag.Tag;
 
+/**
+ * Parses input arguments and creates a new EditCommand object
+ */
 public class NewEditCommandParser implements Parser<EditCommand> {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditCommand
+     * and returns an EditCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public EditCommand parse(String args) throws ParseException {
         Index index;
         CommandTargetType addCommandType;

--- a/src/main/java/tfifteenfour/clipboard/logic/parser/NewEditCommandParser.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/parser/NewEditCommandParser.java
@@ -1,0 +1,153 @@
+package tfifteenfour.clipboard.logic.parser;
+
+import tfifteenfour.clipboard.commons.core.index.Index;
+import tfifteenfour.clipboard.logic.commands.addcommand.AddCourseCommand;
+import tfifteenfour.clipboard.logic.commands.addcommand.AddGroupCommand;
+import tfifteenfour.clipboard.logic.commands.addcommand.AddSessionCommand;
+import tfifteenfour.clipboard.logic.commands.editcommand.EditCommand;
+import tfifteenfour.clipboard.logic.commands.editcommand.EditCourseCommand;
+import tfifteenfour.clipboard.logic.commands.editcommand.EditGroupCommand;
+import tfifteenfour.clipboard.logic.parser.exceptions.ParseException;
+import tfifteenfour.clipboard.model.course.Course;
+import tfifteenfour.clipboard.model.course.Group;
+import tfifteenfour.clipboard.model.course.Session;
+import tfifteenfour.clipboard.model.tag.Tag;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import static tfifteenfour.clipboard.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+public class NewEditCommandParser implements Parser<EditCommand> {
+
+    public EditCommand parse(String args) throws ParseException {
+        Index index;
+        CommandTargetType addCommandType;
+        try {
+            addCommandType = CommandTargetType.fromString(ArgumentTokenizer.tokenizeString(args)[1]);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new ParseException("Add type missing. \n"
+                    + "Available option: add course, add group, add session, add student");
+        }
+
+        switch (addCommandType) {
+        case MODULE:
+            Course newCourse = parseCourseInfo(args);
+            index = parseIndex(args);
+            return new EditCourseCommand(index, newCourse);
+        case GROUP:
+            Group newGroup = parseGroupInfo(args);
+            index = parseIndex(args);
+            return new EditGroupCommand(index, newGroup);
+        case SESSION:
+//            Session session = parseSessionInfo(args);
+//            return new EditSessionCommand(session);
+        case STUDENT:
+//            Student student = parseStudentInfo(args);
+//            return new EditStudentCommand(student);
+        default:
+            throw new ParseException("Invalid argument for add command");
+        }
+    }
+
+    private Index parseIndex(String args) throws ParseException {
+        String[] tokens = ArgumentTokenizer.tokenizeString(args);
+        Index index = ParserUtil.parseIndex(tokens[2]);
+        return index;
+    }
+
+    private Course parseCourseInfo(String args) throws ParseException {
+        String[] tokens = ArgumentTokenizer.tokenizeString(args);
+        if (tokens.length != 4) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCourseCommand.MESSAGE_USAGE));
+        }
+
+        Course course = ParserUtil.parseCourse(tokens[3]);
+        return course;
+    }
+
+    private Group parseGroupInfo(String args) throws ParseException {
+        String[] tokens = ArgumentTokenizer.tokenizeString(args);
+        if (tokens.length != 4) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditGroupCommand.MESSAGE_USAGE));
+        }
+
+        Group group = ParserUtil.parseGroup(tokens[3]);
+        return group;
+    }
+
+    private Session parseSessionInfo(String args) throws ParseException {
+        String[] tokens = ArgumentTokenizer.tokenizeString(args);
+        if (tokens.length != 3) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSessionCommand.MESSAGE_USAGE));
+        }
+
+        Session session = ParserUtil.parseSession(tokens[2]);
+        return session;
+    }
+
+//    private Student parseStudentInfo(String args) throws ParseException {
+//        requireNonNull(args);
+//        ArgumentMultimap argMultimap =
+//                ArgumentTokenizer.tokenizePrefixes(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_STUDENTID,
+//                        PREFIX_COURSE, PREFIX_TAG);
+//
+//        Index index;
+//
+//        try {
+//            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+//        } catch (ParseException pe) {
+//            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, tfifteenfour.clipboard.logic.commands.studentcommands.EditCommand.MESSAGE_USAGE), pe);
+//        }
+//
+//        tfifteenfour.clipboard.logic.commands.studentcommands.EditCommand.EditStudentDescriptor editStudentDescriptor = new tfifteenfour.clipboard.logic.commands.studentcommands.EditCommand.EditStudentDescriptor();
+//        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+//            editStudentDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+//        }
+//        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+//            editStudentDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+//        }
+//        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+//            editStudentDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+//        }
+//        if (argMultimap.getValue(PREFIX_STUDENTID).isPresent()) {
+//            editStudentDescriptor.setStudentId(ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENTID).get()));
+//        }
+//        if (argMultimap.getValue(PREFIX_COURSE).isPresent()) {
+//            parseModulesForEdit(argMultimap.getAllValues(PREFIX_COURSE)).ifPresent(editStudentDescriptor::setModules);
+//        }
+//        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editStudentDescriptor::setTags);
+//
+//        if (!editStudentDescriptor.isAnyFieldEdited()) {
+//            throw new ParseException(tfifteenfour.clipboard.logic.commands.studentcommands.EditCommand.MESSAGE_NOT_EDITED);
+//        }
+//
+//        return new EditStudentCommand(index, editStudentDescriptor);
+//    }
+
+    /**
+     * Parses {@code Collection<String> modules} into a {@code Set<ModuleCode>} if {@code modules} is non-empty.
+     * @throws ParseException if {@code modules} contain only one element which is an empty string
+     */
+    private Optional<Set<Course>> parseModulesForEdit(Collection<String> modules) throws ParseException {
+        Collection<String> moduleSet = modules;
+        return Optional.of(ParserUtil.parseModules(moduleSet));
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseTags(tagSet));
+    }
+}

--- a/src/main/java/tfifteenfour/clipboard/logic/parser/RosterParser.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/parser/RosterParser.java
@@ -62,7 +62,7 @@ public class RosterParser {
             return new AddCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
+            return new NewEditCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);

--- a/src/main/java/tfifteenfour/clipboard/model/course/Group.java
+++ b/src/main/java/tfifteenfour/clipboard/model/course/Group.java
@@ -64,6 +64,10 @@ public class Group {
         return sessions.asUnmodifiableObservableList();
     }
 
+    public ObservableList<Session> getModifiableSessionList() {
+        return sessions.asModifiableObservableList();
+    }
+
     /**
      * Adds the given student to this group.
      * @param student Student to be added.

--- a/src/main/java/tfifteenfour/clipboard/model/course/Session.java
+++ b/src/main/java/tfifteenfour/clipboard/model/course/Session.java
@@ -106,11 +106,20 @@ public class Session {
             newAttendance.put(student, attendance.getOrDefault(student, 0));
         }
         attendance = newAttendance;
-        System.out.println(attendance.keySet());
     }
 
     public void setAttendance(Map<Student, Integer> attendance) {
         this.attendance = new HashMap<>(attendance);
+    }
+
+    public void replaceStudent(Student oldStudent, Student newStudent) {
+        if (!attendance.containsKey(oldStudent)) {
+            throw new StudentNotInSessionException();
+        } else {
+            int value = attendance.get(oldStudent);
+            attendance.remove(oldStudent);
+            attendance.put(newStudent, value);
+        }
     }
 
     /**

--- a/src/main/java/tfifteenfour/clipboard/model/course/Session.java
+++ b/src/main/java/tfifteenfour/clipboard/model/course/Session.java
@@ -109,6 +109,10 @@ public class Session {
         System.out.println(attendance.keySet());
     }
 
+    public void setAttendance(Map<Student, Integer> attendance) {
+        this.attendance = new HashMap<>(attendance);
+    }
+
     /**
      * Marks the given student as present in this session.
      *

--- a/src/main/java/tfifteenfour/clipboard/model/course/Session.java
+++ b/src/main/java/tfifteenfour/clipboard/model/course/Session.java
@@ -112,6 +112,11 @@ public class Session {
         this.attendance = new HashMap<>(attendance);
     }
 
+    /**
+     * Replaces a student in current session with a new student.
+     * @param oldStudent Student to be replaced.
+     * @param newStudent New student to replace with.
+     */
     public void replaceStudent(Student oldStudent, Student newStudent) {
         if (!attendance.containsKey(oldStudent)) {
             throw new StudentNotInSessionException();


### PR DESCRIPTION
== READY TO MERGE ==

### Updated Commands
- `edit course`
- `edit group`
- `edit session`
- `edit student`

Note: Modification made to students will not automatically propagate to session since `Student` is not the same object after editting, so I manually update them in the function `EditStudentCommand::execute` , maybe need to do something similar for `tasks` @IsabelChong 
```
for (Session session : sessions) {
    session.replaceStudent(studentToEdit, editedStudent);
}
```