### PR TITLE
Fix invalid storage file causes application to be unable to start

### DIFF
--- a/src/main/java/tfifteenfour/clipboard/MainApp.java
+++ b/src/main/java/tfifteenfour/clipboard/MainApp.java
@@ -95,7 +95,11 @@ public class MainApp extends Application {
         } catch (DataConversionException e) {
             logger.warning("Data file not in the correct format. " + MESSAGE_SAMPLE);
             initialData = SampleDataUtil.getSampleRoster(sampleFilePath, sampleResourceStream);
-        } catch (IOException e) {
+        } catch (IllegalArgumentException e) {
+            logger.warning("Invalid data detected. " + MESSAGE_SAMPLE);
+            initialData = SampleDataUtil.getSampleRoster(sampleFilePath, sampleResourceStream);
+        }
+        catch (IOException e) {
             logger.warning("Problem while reading from the file. " + MESSAGE_SAMPLE);
             initialData = SampleDataUtil.getSampleRoster(sampleFilePath, sampleResourceStream);
 


### PR DESCRIPTION
... by catching `IllegalArgumentException` when loading storage

Fixes #187 