### PR TITLE
Fix command result for delete

### DIFF
--- a/src/main/java/tfifteenfour/clipboard/logic/commands/deletecommand/DeleteGroupCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/deletecommand/DeleteGroupCommand.java
@@ -26,8 +26,7 @@ public class DeleteGroupCommand extends DeleteCommand {
             + "Example: " + COMMAND_WORD + " " + COMMAND_TYPE_WORD
             + " " + " 1";
 
-    public static final String MESSAGE_SUCCESS = "Group deleted in %1$s: %2$s";
-    public static final String MESSAGE_DUPLICATE_GROUP = "This group already exists in the course";
+    public static final String MESSAGE_SUCCESS = "Deleted group in %1$s: %2$s";
 
     private final Index index;
 
@@ -59,7 +58,7 @@ public class DeleteGroupCommand extends DeleteCommand {
         Group groupToDelete = lastShownList.get(index.getZeroBased());
         selectedCourse.deleteGroup(groupToDelete);
 
-        return new CommandResult(this, String.format(MESSAGE_SUCCESS, groupToDelete, selectedCourse), willModifyState);
+        return new CommandResult(this, String.format(MESSAGE_SUCCESS, selectedCourse, groupToDelete), willModifyState);
     }
 
     @Override

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/deletecommand/DeleteSessionCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/deletecommand/DeleteSessionCommand.java
@@ -32,6 +32,7 @@ public class DeleteSessionCommand extends DeleteCommand {
 
     /**
      * Creates a {@code DeleteSessionCommand} to delete the session at the specified {@code Index}.
+     *
      * @param index Index of the session to be deleted.
      */
     public DeleteSessionCommand(Index index) {
@@ -64,6 +65,6 @@ public class DeleteSessionCommand extends DeleteCommand {
         Session sessionToDelete = lastShownList.get(index.getZeroBased());
         selectedGroup.deleteSession(sessionToDelete);
 
-        return new CommandResult(this, String.format(MESSAGE_SUCCESS, sessionToDelete, selectedGroup), willModifyState);
+        return new CommandResult(this, String.format(MESSAGE_SUCCESS, selectedGroup, sessionToDelete), willModifyState);
     }
 }

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/deletecommand/DeleteTaskCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/deletecommand/DeleteTaskCommand.java
@@ -32,6 +32,7 @@ public class DeleteTaskCommand extends DeleteCommand {
 
     /**
      * Creates a {@code DeleteTaskCommand} to delete the task at the specified {@code Index}.
+     *
      * @param index Index of the task to be deleted.
      */
     public DeleteTaskCommand(Index index) {
@@ -64,6 +65,6 @@ public class DeleteTaskCommand extends DeleteCommand {
         Task taskToDelete = lastShownList.get(index.getZeroBased());
         selectedGroup.deleteTask(taskToDelete);
 
-        return new CommandResult(this, String.format(MESSAGE_SUCCESS, taskToDelete, selectedGroup), willModifyState);
+        return new CommandResult(this, String.format(MESSAGE_SUCCESS, selectedGroup, taskToDelete), willModifyState);
     }
 }


### PR DESCRIPTION
Closes #169 

Fixes order of command result for `delete group`, `delete session` and  `delete tasks` 
"Group deleted in T14: CS2103T" -> "Deleted group in CS2103T: T14"