### PR TITLE
Fix remark command

### DIFF
--- a/src/main/java/tfifteenfour/clipboard/logic/commands/studentcommands/RemarkCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/studentcommands/RemarkCommand.java
@@ -29,13 +29,10 @@ public class RemarkCommand extends Command {
             + ": Edits the remark of the person identified "
             + "by the index number used in the last person listing. "
             + "Existing remark will be overwritten by the input.\n"
-            + "Parameters: INDEX (must be a positive integer) "
-            + "r/ [REMARK]\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + "r/ Likes to swim.";
+            + "Parameters: INDEX (must be a positive integer) [REMARK]\n"
+            + "Example: " + COMMAND_WORD + " 1 Likes to swim.";
 
 
-    public static final String MESSAGE_ARGUMENTS = "Index: %1$d, Remark: %2$s";
     public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to student: %1$s, Remark: %2$s";
     public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from student: %1$s";
 
@@ -64,8 +61,7 @@ public class RemarkCommand extends Command {
         List<Task> tasks = selectedGroup.getModifiableTaskList();
 
 
-
-        if (index.getZeroBased() >= lastShownList.size()) {
+        if (index.getZeroBased() >= lastShownList.size() || index.getZeroBased() < 0) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 

--- a/src/main/java/tfifteenfour/clipboard/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/parser/ArgumentMultimap.java
@@ -57,4 +57,11 @@ public class ArgumentMultimap {
     public String getPreamble() {
         return getValue(new Prefix("")).orElse("");
     }
+
+    /**
+     * Returns the size of the map.
+     */
+    public int size() {
+        return argMultimap.size();
+    }
 }

--- a/src/main/java/tfifteenfour/clipboard/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/parser/RemarkCommandParser.java
@@ -38,6 +38,8 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
 
         if (currentSelection.getCurrentPage() != PageType.STUDENT_PAGE) {
             throw new CommandException("Wrong page. Navigate to student page to add a remark");
+        } else if (argMultimap.size() <= 1) {
+            throw new CommandException("Wrong command format. " + RemarkCommand.MESSAGE_USAGE);
         }
 
         try {

--- a/src/main/java/tfifteenfour/clipboard/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/parser/RemarkCommandParser.java
@@ -2,7 +2,6 @@ package tfifteenfour.clipboard.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static tfifteenfour.clipboard.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static tfifteenfour.clipboard.logic.parser.CliSyntax.PREFIX_REMARK;
 
 import java.util.Arrays;
 
@@ -33,31 +32,29 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
      */
     public RemarkCommand parse(String args) throws ParseException, CommandException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenizePrefixes(args, PREFIX_REMARK);
         Index index;
+        Remark remark;
 
         if (currentSelection.getCurrentPage() != PageType.STUDENT_PAGE) {
             throw new CommandException("Wrong page. Navigate to student page to add a remark");
-        } else if (argMultimap.size() <= 1) {
-            throw new CommandException("Wrong command format. " + RemarkCommand.MESSAGE_USAGE);
         }
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            index = ParserUtil.parseIndex(args);
+            remark = new Remark(parseRemarkInfo(args));
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     RemarkCommand.MESSAGE_USAGE), ive);
         }
-        Remark remark = new Remark(argMultimap.getValue(PREFIX_REMARK).orElse(""));
+
         return new RemarkCommand(index, remark);
     }
 
     private String parseRemarkInfo(String args) throws ParseException {
         String[] tokens = ArgumentTokenizer.tokenizeString(args);
-        System.out.println(tokens.length);
-        //if (tokens.length < 3) {
-        //    throw new ParseException("Remark not entered");
-        //}
+        if (tokens.length < 2) {
+            throw new ParseException("Remark not entered!\n" + RemarkCommand.MESSAGE_USAGE);
+        }
 
         return String.join(" ", Arrays.copyOfRange(tokens, 2, tokens.length));
 

--- a/src/main/java/tfifteenfour/clipboard/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/parser/RemarkCommandParser.java
@@ -6,7 +6,6 @@ import static tfifteenfour.clipboard.commons.core.Messages.MESSAGE_INVALID_COMMA
 import java.util.Arrays;
 
 import tfifteenfour.clipboard.commons.core.index.Index;
-import tfifteenfour.clipboard.commons.exceptions.IllegalValueException;
 import tfifteenfour.clipboard.logic.CurrentSelection;
 import tfifteenfour.clipboard.logic.PageType;
 import tfifteenfour.clipboard.logic.commands.exceptions.CommandException;
@@ -39,13 +38,8 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
             throw new CommandException("Wrong page. Navigate to student page to add a remark");
         }
 
-        try {
-            index = ParserUtil.parseIndex(args);
-            remark = new Remark(parseRemarkInfo(args));
-        } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    RemarkCommand.MESSAGE_USAGE), ive);
-        }
+        remark = new Remark(parseRemarkInfo(args));
+        index = ParserUtil.parseIndex(args);
 
         return new RemarkCommand(index, remark);
     }
@@ -53,7 +47,8 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
     private String parseRemarkInfo(String args) throws ParseException {
         String[] tokens = ArgumentTokenizer.tokenizeString(args);
         if (tokens.length < 2) {
-            throw new ParseException("Remark not entered!\n" + RemarkCommand.MESSAGE_USAGE);
+            throw new ParseException( String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RemarkCommand.MESSAGE_USAGE));
         }
 
         return String.join(" ", Arrays.copyOfRange(tokens, 2, tokens.length));


### PR DESCRIPTION
Fixes #203 

### Changes
Format: `remark <INDEX> [REMARK]`, e.g. `remark 1 loves to read`, `remark 1`