### PR TITLE
Fix `upload` to reject non-PNG file

### DIFF
--- a/src/main/java/tfifteenfour/clipboard/logic/commands/UploadCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/UploadCommand.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
@@ -92,7 +93,7 @@ public class UploadCommand extends Command {
 
             Files.copy(sourcePath, destPath.resolve(sourcePath.getFileName()), REPLACE_EXISTING);
             return new CommandResult(this, generateSuccessMessage(sourcePath), willModifyState);
-        } catch (IOException e) {
+        } catch (InvalidPathException | IOException e) {
             throw new CommandException(MESSAGE_INVALID_FILEPATH);
         }
     }

--- a/src/main/java/tfifteenfour/clipboard/logic/commands/UploadCommand.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/commands/UploadCommand.java
@@ -8,10 +8,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Iterator;
 
 import tfifteenfour.clipboard.logic.PageType;
 import tfifteenfour.clipboard.logic.commands.exceptions.CommandException;
 import tfifteenfour.clipboard.model.Model;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
 
 /**
  * Uploads a file to CLIpboard. If file already exists in CLIpboard, old file will be overwritten.
@@ -71,6 +75,21 @@ public class UploadCommand extends Command {
             if (!toCopy.isFile()) {
                 throw new CommandException("Please upload a valid file.");
             }
+
+            ImageInputStream iis = ImageIO.createImageInputStream(toCopy);
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
+
+            if (!readers.hasNext()) {
+                throw new CommandException("Please upload a PNG file.");
+            }
+
+            String formatName = readers.next().getFormatName();
+
+            if (!"png".equalsIgnoreCase(formatName)) {
+                throw new CommandException("Please upload a PNG file.");
+            }
+
+
             Files.copy(sourcePath, destPath.resolve(sourcePath.getFileName()), REPLACE_EXISTING);
             return new CommandResult(this, generateSuccessMessage(sourcePath), willModifyState);
         } catch (IOException e) {

--- a/src/main/java/tfifteenfour/clipboard/logic/parser/UploadCommandParser.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/parser/UploadCommandParser.java
@@ -2,6 +2,7 @@ package tfifteenfour.clipboard.logic.parser;
 
 import static tfifteenfour.clipboard.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -13,7 +14,7 @@ import tfifteenfour.clipboard.logic.parser.exceptions.ParseException;
  */
 public class UploadCommandParser implements Parser<UploadCommand> {
 
-
+    public static final String MESSAGE_INVALID_FILEPATH = "File path is not valid!";
 
     /**
      * Parses the given {@code String} of arguments in the context of the UploadCommand
@@ -26,7 +27,11 @@ public class UploadCommandParser implements Parser<UploadCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UploadCommand.MESSAGE_USAGE));
         }
 
-        Path sourcePath = Paths.get(trimmedArgs);
-        return new UploadCommand(sourcePath);
+        try {
+            Path sourcePath = Paths.get(trimmedArgs);
+            return new UploadCommand(sourcePath);
+        } catch (InvalidPathException e) {
+            throw new ParseException(MESSAGE_INVALID_FILEPATH);
+        }
     }
 }


### PR DESCRIPTION
1. reject non-PNG file
2. fix runtime error cause by invalid file path, e.g. calling `upload "FILE_PATH"` will throw `InvalidPathException` that is not handled

=READY=