### PR TITLE
Fix condition in StudentParticularsContainsPredicate

### DIFF
--- a/src/main/java/tfifteenfour/clipboard/logic/predicates/StudentParticularsContainsPredicate.java
+++ b/src/main/java/tfifteenfour/clipboard/logic/predicates/StudentParticularsContainsPredicate.java
@@ -18,32 +18,12 @@ public class StudentParticularsContainsPredicate implements Predicate<Student> {
 
     @Override
     public boolean test(Student student) {
-        if (isValidStudentIdKeyword(keywords)) {
-            return keywords.stream()
-                    .anyMatch(keyword -> student.getStudentId()
-                    .toString().toLowerCase().contains(keyword.toLowerCase()));
-        } else {
-            return keywords.stream()
-                    .anyMatch(keyword -> student.getName().toString()
-                    .toLowerCase().contains(keyword.toLowerCase()));
-        }
-    }
-
-    /**
-     * Checks whether keyword is a student ID by checking if the middle 7 characters are numeric
-     * @param keywords
-     * @return boolean
-     */
-    public boolean isValidStudentIdKeyword(List<String> keywords) {
-        String firstKeyword = keywords.get(0);
-        if (firstKeyword.length() < 7) {
-            return false;
-        }
-        return isNumeric(firstKeyword.substring(1, 7));
-    }
-
-    public boolean isNumeric(String string) {
-        return string.matches("-?\\d+(\\.\\d+)?");
+        return keywords.stream()
+                .anyMatch(keyword -> student.getStudentId()
+                .toString().toLowerCase().contains(keyword.toLowerCase())) ||
+                keywords.stream()
+                .anyMatch(keyword -> student.getName()
+                .toString().toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override


### PR DESCRIPTION
fixes #232 

`find student <keyword>` no longer check for valid sid, updates to UG needed. (done in #239)

READY